### PR TITLE
feat: modify article order by time 

### DIFF
--- a/articles/How to Migrate an Ethereum Protocol to Solana-Preamble/README.md
+++ b/articles/How to Migrate an Ethereum Protocol to Solana-Preamble/README.md
@@ -19,6 +19,8 @@ heroColor: "#398DAD"
 thumb: "thumb.png"
 thumb_h: "thumb-h.png"
 intro: "A systematic introduction to the fundamental differences between Ethereum and Solana in account models, execution mechanisms, and fee systems."
+top: true
+weight: 998 
 ---
 
 ## Overview

--- a/articles/The Architecture of Startup Distributed Teams/README.md
+++ b/articles/The Architecture of Startup Distributed Teams/README.md
@@ -12,6 +12,8 @@ thumb: "./thumb.png"
 thumb_h: "./thumb_h.png"
 intro: ""
 previousSlugs: []
+top: true
+weight: 1000
 ---
 
 Over the past decade, I’ve overseen the launch of over 120 MVPs. I’ve watched companies evolve from napkin sketches to Series C scale, some as independent startups, others as incubated ventures within mature tech organizations. Combined with my experience running global engineering teams as a VP of Engineering for a public company, this vantage point has taught me a singular truth: distributed work succeeds brilliantly, or it fails in ways that slow companies down for years.

--- a/articles/The Rising Strategic Value of Creative in Digital Advertising/README.md
+++ b/articles/The Rising Strategic Value of Creative in Digital Advertising/README.md
@@ -11,6 +11,8 @@ heroColor: "#8761B1"
 thumb: "./thumb.png"
 thumb_h: "./thumb_h.png"
 intro: "Creative has emerged as a key driver influencing success in performance marketing, and digital advertising companies are increasingly asked to facilitate the creation of advertisements. How did we get here, and what comes next?"
+top: true
+weight: 999
 ---
 
 The digital advertising landscape has recently undergone a significant shift in the wake of short-form video, privacy initiatives, and generative AI. As a result, the industry has moved toward recognizing creative iteration as a primary performance lever. In this article, we’ll recount the history of digital advertising as it pertains to the importance of creative and articulate the current landscape of relevant players. The takeaway is clear: modern advertising platforms are facing mounting pressure to embed creative iteration directly into the performance advertising workflow.

--- a/scripts/file.js
+++ b/scripts/file.js
@@ -74,14 +74,6 @@ export function extractMeta(fileName) {
 
 export function sortMetadata(metaDataList) {
   metaDataList.sort((a, b) => {
-    if (a.top !== b.top) {
-      return a.top ? -1 : 1;
-    }
-
-    if (a.weight !== b.weight) {
-      return b.weight - a.weight;
-    }
-
     try {
       return new Date(b.createTime) - new Date(a.createTime);
     } catch (e) {


### PR DESCRIPTION
## Description
The website expects the article list to be ordered by `createTime` only. The latest article needs to be at the front.

In addition, some articles are added to the `top` and `weight` in order to collect data and display the carousel.